### PR TITLE
Fix AR library loading paths

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -796,8 +796,8 @@ async function ensureARLibsLoaded() {
   }
   if (!arLibsPromise) {
     arLibsPromise = (async () => {
-      await loadScript('./libs/aframe.min.js');
-      await loadScript('./libs/mindar-image-aframe.prod.js');
+      await loadScript('/libs/aframe.min.js');
+      await loadScript('/libs/mindar-image-aframe.prod.js');
     })();
   }
   await arLibsPromise;


### PR DESCRIPTION
## Summary
- load the MindAR and A-Frame bundles from the site root so dynamic loading works under static hosting

## Testing
- python3 -m http.server 3000
- curl -I http://localhost:3000/ar/demo/
- curl -I http://localhost:3000/libs/aframe.min.js
- curl -I http://localhost:3000/libs/mindar-image-aframe.prod.js

------
https://chatgpt.com/codex/tasks/task_e_68cfc77c2d4883339563d620971c9785