### PR TITLE
Fix manifest URL resolution for nested base paths

### DIFF
--- a/js/manifest.js
+++ b/js/manifest.js
@@ -174,7 +174,24 @@ function ensureString(value) {
 
 function buildManifestUrl(slug) {
   const sanitized = encodeURIComponent(slug);
-  const relative = `ar/${sanitized}/manifest.json`;
-  const base = `${window.location.origin}/`;
-  return new URL(relative, base).toString();
+  const { origin, pathname } = window.location;
+  const segments = pathname.split('/').filter(Boolean);
+  const arIndex = segments.indexOf('ar');
+
+  let prefixSegments;
+  if (arIndex !== -1) {
+    prefixSegments = segments.slice(0, arIndex);
+  } else {
+    prefixSegments = [...segments];
+    if (
+      prefixSegments.length &&
+      prefixSegments[prefixSegments.length - 1].includes('.')
+    ) {
+      prefixSegments = prefixSegments.slice(0, -1);
+    }
+  }
+
+  const prefixPath = prefixSegments.length ? `/${prefixSegments.join('/')}/` : '/';
+  const manifestPath = `${prefixPath}ar/${sanitized}/manifest.json`;
+  return new URL(manifestPath, `${origin}/`).toString();
 }


### PR DESCRIPTION
## Summary
- update buildManifestUrl to preserve any path segments that precede the ar/ directory
- ensure manifests resolve correctly when the site is served from a nested base path such as /aryeimy

## Testing
- python3 -m http.server 8000 (manual verification)
- node --input-type=module <<'NODE' (manual verification)
  global.window = { location: new URL('http://localhost:8000/aryeimy/ar/demo/') };
  const { fetchManifest } = await import('./js/manifest.js');
  const manifest = await fetchManifest('demo');
  console.log('Loaded manifest URL:', manifest.url);
  console.log('Manifest title:', manifest.title);
  NODE

------
https://chatgpt.com/codex/tasks/task_e_68cfcf79fab08333aa2fc9369c596efd