### PR TITLE
Preserve ar subdirectory prefix during canonicalization

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -110,7 +110,31 @@ function ensureCanonicalUrl(slug) {
   }
 
   const { pathname, search, hash } = window.location;
-  const canonicalPath = `/ar/${encodeURIComponent(slug)}/`;
+  const pathSegments = pathname.split('/');
+  const arIndex = pathSegments.findIndex((segment) => segment === 'ar');
+  let baseSegments;
+
+  if (arIndex !== -1) {
+    baseSegments = pathSegments.slice(0, arIndex + 1);
+  } else {
+    baseSegments = pathSegments.slice();
+    while (baseSegments.length > 1 && baseSegments[baseSegments.length - 1] === '') {
+      baseSegments.pop();
+    }
+    baseSegments.push('ar');
+  }
+
+  const normalizedBaseSegments = baseSegments.filter(
+    (segment, index) => index === 0 || segment
+  );
+
+  if (normalizedBaseSegments.length === 0 || normalizedBaseSegments[0] !== '') {
+    normalizedBaseSegments.unshift('');
+  }
+
+  const canonicalSegments = [...normalizedBaseSegments, encodeURIComponent(slug), ''];
+  const canonicalPath = canonicalSegments.join('/');
+
   const params = new URLSearchParams(search || '');
   const hasSlugParam = params.has('slug');
   params.delete('slug');


### PR DESCRIPTION
## Summary
- update canonical URL logic to retain any leading path segments before the `ar/` directory
- continue normalizing the slug portion and stripping redundant `slug` query parameters

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cfd0c12e3883339f7739ed03087f24