### PR TITLE
Ensure MindAR stub video playback starts on Safari

### DIFF
--- a/libs/mindar-image-aframe.prod.js
+++ b/libs/mindar-image-aframe.prod.js
@@ -63,6 +63,15 @@
         try {
           const stream = await navigator.mediaDevices.getUserMedia({ video: { facingMode: 'environment' }, audio: false });
           video.srcObject = stream;
+          try {
+            await video.play();
+          } catch (playError) {
+            console.error('[MindAR:stub] Unable to start camera playback; falling back to placeholder frame.', playError);
+            if (stream && stream.getTracks){
+              stream.getTracks().forEach(track => track.stop());
+            }
+            this._usePlaceholderFrame();
+          }
         } catch (error) {
           console.warn('[MindAR:stub] Unable to access camera; falling back to placeholder frame.', error);
           this._usePlaceholderFrame();


### PR DESCRIPTION
## Summary
- await camera video playback in the MindAR stub so browsers such as Safari render the stream
- log and fall back to the placeholder frame if playback fails, ensuring camera tracks are released

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cfd775ed0c83338decaed61a302979