### PR TITLE
Ensure MindAR video element uses inline playback attributes

### DIFF
--- a/libs/mindar-image-aframe.prod.js
+++ b/libs/mindar-image-aframe.prod.js
@@ -47,6 +47,10 @@
     async _setupVideo(){
       if (this.videoEl) return;
       const video = document.createElement('video');
+      video.setAttribute('playsinline', 'true');
+      video.setAttribute('webkit-playsinline', 'true');
+      video.setAttribute('autoplay', 'true');
+      video.setAttribute('muted', 'true');
       video.playsInline = true;
       video.autoplay = true;
       video.muted = true;


### PR DESCRIPTION
## Summary
- ensure the stub controller's video element includes inline playback-related attributes to match its property assignments

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cfdc0443ac8333a2dced9d1b512510