### PR TITLE
Add mobile inline autoplay attributes to MindAR stub video

### DIFF
--- a/libs/mindar-image-aframe.prod.js
+++ b/libs/mindar-image-aframe.prod.js
@@ -47,6 +47,10 @@
     async _setupVideo(){
       if (this.videoEl) return;
       const video = document.createElement('video');
+      video.setAttribute('playsinline', 'true');
+      video.setAttribute('webkit-playsinline', 'true');
+      video.setAttribute('autoplay', 'true');
+      video.setAttribute('muted', 'true');
       video.playsInline = true;
       video.autoplay = true;
       video.muted = true;


### PR DESCRIPTION
## Summary
- ensure the MindAR stub video element includes inline, autoplay, and muted attributes for better mobile compatibility

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cfdce010288333803db7d1d3620694