### PR TITLE
Use MindAR system start when available

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -461,14 +461,24 @@ async function startARScene() {
 }
 
 async function startMindARScene(sceneEl) {
+  const system = sceneEl.systems ? sceneEl.systems['mindar-image-system'] : null;
+  if (system && typeof system.start === 'function') {
+    await system.start();
+    return;
+  }
+
   let component = sceneEl.components ? sceneEl.components['mindar-image'] : null;
   if (!component) {
     component = await waitForComponent(sceneEl, 'mindar-image');
   }
   if (component && typeof component.play === 'function') {
-    await component.play();
+    const result = component.play();
+    if (result && typeof result.then === 'function') {
+      await result;
+    }
     return;
   }
+
   const event = new CustomEvent('mindar-start');
   sceneEl.dispatchEvent(event);
 }


### PR DESCRIPTION
## Summary
- start the MindAR image system when available so permission errors propagate correctly
- keep the existing play/event fallback for environments without the system

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68cfe99df1d4833389514431b3f1f6be