### PR TITLE
Set A-Frame stub scene loaded flags

### DIFF
--- a/libs/aframe.min.js
+++ b/libs/aframe.min.js
@@ -92,6 +92,7 @@
         super();
         this.__aframeComponents = {};
         this.components = this.__aframeComponents;
+        this.hasLoaded = false;
       }
       connectedCallback(){
         instantiateAllComponents(this);
@@ -101,6 +102,8 @@
           this.style.width = '100%';
           this.style.height = '100%';
           scenes.push(this);
+          this.hasLoaded = true;
+          this.isLoaded = true;
           const event = new Event('loaded');
           setTimeout(() => this.dispatchEvent(event));
         }


### PR DESCRIPTION
## Summary
- initialize the A-Frame stub scene element with a hasLoaded flag
- ensure the stub scene marks itself loaded before dispatching the delayed event

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cfec8d9a688333b4d64cb13d37bbb8